### PR TITLE
Fetch buyers with owner details

### DIFF
--- a/src/lib/db/queries.ts
+++ b/src/lib/db/queries.ts
@@ -1,5 +1,5 @@
 import { db } from './index';
-import { buyers, buyerHistory, authUsers } from './schema';
+import { buyers, buyerHistory, authUsers, users } from './schema';
 import { eq, and, or, ilike, desc, asc, count } from 'drizzle-orm';
 import type { BuyerFilters } from '@/lib/validations/buyer';
 
@@ -26,9 +26,9 @@ export async function getBuyers(filters: BuyerFilters, userId?: string) {
     createdAt: buyers.createdAt,
     updatedAt: buyers.updatedAt,
     owner: {
-      id: users.id,
-      name: users.name,
-      email: users.email,
+      id: authUsers.id,
+      name: authUsers.name,
+      email: authUsers.email,
     },
   }).from(buyers).leftJoin(authUsers, eq(buyers.ownerId, authUsers.id)) as any;
 
@@ -173,13 +173,13 @@ export async function getBuyerHistory(buyerId: string) {
     changedAt: buyerHistory.changedAt,
     diff: buyerHistory.diff,
     changedBy: {
-      id: authUsers.id,
-      name: authUsers.name,
-      email: authUsers.email,
+      id: users.id,
+      name: users.name,
+      email: users.email,
     },
   })
   .from(buyerHistory)
-  .leftJoin(authUsers, eq(buyerHistory.changedBy, authUsers.id))
+  .leftJoin(users, eq(buyerHistory.changedBy, users.id))
   .where(eq(buyerHistory.buyerId, buyerId))
   .orderBy(desc(buyerHistory.changedAt))
   .limit(5);
@@ -202,7 +202,7 @@ export async function getBuyersStats(userId?: string) {
   }
 
   const stats = await statsQuery;
-  const total = stats.reduce((sum, stat) => sum + stat.count, 0);
+  const total = stats.reduce((sum: number, stat: { count: number }) => sum + stat.count, 0);
 
   return { stats, total };
 }


### PR DESCRIPTION
Fix "users is not defined" error in `getBuyers` and align `getBuyerHistory` join.

The `getBuyers` function was referencing `users` instead of `authUsers` for the `owner` projection, causing a runtime error. This PR corrects the reference to `authUsers`. Additionally, `getBuyerHistory` was incorrectly joining `authUsers` for the `changedBy` field, while `buyerHistory.changedBy` references the application's `users` table; this has been corrected. Explicit types were also added to the reducer in `getBuyersStats` for improved type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8d1b296-7fa7-4e6d-a237-0432e5ef7ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8d1b296-7fa7-4e6d-a237-0432e5ef7ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

